### PR TITLE
Cambiar nombre de la página principal

### DIFF
--- a/PDS2_Store/Views/Shared/_Layout.cshtml
+++ b/PDS2_Store/Views/Shared/_Layout.cshtml
@@ -18,7 +18,7 @@
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                @Html.ActionLink("Nombre de la aplicación", "Index", "Home", new { area = "" }, new { @class = "navbar-brand" })
+                @Html.ActionLink("PDS2 Store", "Index", "Home", new { area = "" }, new { @class = "navbar-brand" })
             </div>
             <div class="navbar-collapse collapse">
                 <ul class="nav navbar-nav">


### PR DESCRIPTION
Se cambió el nombre a "PDS2 Store" porque el nombre que te crea por defecto es "Nombre de la aplicación"